### PR TITLE
fix: no action_representation_module in CB constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-pearl/utils/scripts/cb_benchmark/utils/*
+pearl/utils/scripts/cb_benchmark/experiments_results/*
+pearl/utils/scripts/cb_benchmark/instantiations/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,131 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+pearl/utils/scripts/cb_benchmark/utils/*

--- a/pearl/utils/scripts/cb_benchmark/cb_benchmark_config.py
+++ b/pearl/utils/scripts/cb_benchmark/cb_benchmark_config.py
@@ -6,6 +6,7 @@
 #
 
 import os
+
 from typing import Any, Dict, Tuple
 
 import torch

--- a/pearl/utils/scripts/cb_benchmark/cb_benchmark_config.py
+++ b/pearl/utils/scripts/cb_benchmark/cb_benchmark_config.py
@@ -30,7 +30,7 @@ from pearl.utils.instantiations.environments.contextual_bandit_uci_environment i
     SLCBEnvironment,
 )
 
-DATA_PATH: str = "./utils/instantiations/environments/uci_datasets"
+DATA_PATH: str = "./instantiations/environments/uci_datasets"
 
 """
 Experiment config

--- a/pearl/utils/scripts/cb_benchmark/run_cb_benchmarks.py
+++ b/pearl/utils/scripts/cb_benchmark/run_cb_benchmarks.py
@@ -6,9 +6,7 @@
 #
 
 import os
-import sys
 
-sys.path.append("/home/cryptexis/projects/open_source/Pearl/")
 import random
 from typing import Any, Dict, List, Optional
 
@@ -206,10 +204,12 @@ def run_experiments(
                 **exploration_module_dict["params"]
             )
             policy_learner_dict["params"]["exploration_module"] = exploration_module
-            action_representation_module = policy_learner_dict["params"].pop('action_representation_module')
+            action_representation_module = policy_learner_dict["params"]['action_representation_module']
+            policy_learner_dict["params"].pop('action_representation_module')
             policy_learner = policy_learner_dict["method"](
                 **policy_learner_dict["params"]
             )
+            policy_learner_dict['params']['action_representation_module'] = action_representation_module
             # override action representation module
             policy_learner._action_representation_module = action_representation_module
 
@@ -261,13 +261,13 @@ def run_experiments(
 def run_cb_benchmarks() -> None:
 
     # Download uci datasets if dont exist
-    uci_data_path = "./utils/instantiations/environments/uci_datasets"
+    uci_data_path = "./instantiations/environments/uci_datasets"
     if not os.path.exists(uci_data_path):
         os.makedirs(uci_data_path)
         download_uci_data(data_path=uci_data_path)
 
     # Path to save results
-    save_results_path: str = "./utils/scripts/cb_benchmark/experiments_results"
+    save_results_path: str = "./experiments_results"
 
     # load UCI dataset
     valid_env_dict: Dict[str, Any] = {
@@ -286,6 +286,7 @@ def run_cb_benchmarks() -> None:
         "OfflineEval": return_offline_eval_config,
     }
 
+    print(valid_env_dict)
     # run all CB algorithms on all benchmarks
     for algorithm in return_cb_config.keys():
         for dataset_name in valid_env_dict.keys():

--- a/pearl/utils/scripts/cb_benchmark/run_cb_benchmarks.py
+++ b/pearl/utils/scripts/cb_benchmark/run_cb_benchmarks.py
@@ -6,6 +6,9 @@
 #
 
 import os
+import sys
+
+sys.path.append("/home/cryptexis/projects/open_source/Pearl/")
 import random
 from typing import Any, Dict, List, Optional
 
@@ -203,13 +206,12 @@ def run_experiments(
                 **exploration_module_dict["params"]
             )
             policy_learner_dict["params"]["exploration_module"] = exploration_module
+            action_representation_module = policy_learner_dict["params"].pop('action_representation_module')
             policy_learner = policy_learner_dict["method"](
                 **policy_learner_dict["params"]
             )
             # override action representation module
-            policy_learner._action_representation_module = policy_learner_dict[
-                "params"
-            ]["action_representation_module"]
+            policy_learner._action_representation_module = action_representation_module
 
             regret_single_run = run_experiments_online(
                 env, policy_learner, T, replay_buffer_size=T


### PR DESCRIPTION
There is an error in when trying to run benchmarks:

configs are defined the following way:

```
policy_learner_dict: Dict[str, Any] = {
    "name": "NeuralBandit",
    "method": NeuralBandit,
    "params": {
        "feature_dim": feature_dim + dim_actions,
        "hidden_dims": [64, 16],
        "learning_rate": 0.01,
        "batch_size": 128,
        "training_rounds": run_config["training_rounds"],
        "action_representation_module": BinaryActionTensorRepresentationModule(
            bits_num=dim_actions
        ),
    },
}
```

and then then the `NeuralBandit` object is created the following way:

```
policy_learner = policy_learner_dict["method"](
    **policy_learner_dict["params"]
)
```
However, neither `ContextualBanditBase` nor any of the classes that extend it take `action_representation_module` as constructor parameter.

In addition, I have added standard python `.gitignore`  with added exclusion of dataset/result paths for the benchmark