### PR TITLE
fix: adding gitignore and fixing missing imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,137 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+*.pickle
+*.pt
+test/MNIST
+test/*.png
+pearl/utils/scripts/cb_benchmark/experiments_results/
+pearl/utils/instantiations/environments/uci_datasets/
+pearl/utils/scripts/cb_benchmark/utils/

--- a/pearl/utils/scripts/benchmark.py
+++ b/pearl/utils/scripts/benchmark.py
@@ -34,21 +34,7 @@ from pearl.utils.scripts.benchmark_config import (  # noqa
     benchmark_halfcheetah_v4,  # noqa
     benchmark_hopper_v4,  # noqa
     benchmark_walker2d_v4,  # noqa
-    generate_rctd3_ant,  # noqa
-    generate_rctd3_half_cheetah_v1,  # noqa
-    generate_rctd3_hopper,  # noqa
-    generate_rctd3_walker,  # noqa
     get_env,
-    rctd3_ant_part_1,  # noqa
-    rctd3_ant_part_2,  # noqa
-    rctd3_ant_part_3,  # noqa
-    rctd3_ant_part_4,  # noqa
-    rctd3_half_cheetah_v1_part_1,  # noqa
-    rctd3_half_cheetah_v1_part_2,  # noqa
-    rctd3_hopper_part_1,  # noqa
-    rctd3_hopper_part_2,  # noqa
-    rctd3_walker_part_1,  # noqa
-    rctd3_walker_part_2,  # noqa
     test_dynamic_action_space,
 )
 


### PR DESCRIPTION
- added gitignore file. Since cb_benchmarks download data. Depending from which location in the project one calls the file the location where data is downloaded changes. As a quick fix I have added paths to the .gitignore: 
1. when `run_cb_benchmakrs.py` is called from `pearl` dir, 
2. b. when `run_cb_benchmarks.py` is called from `utils/scripts/cb_benchmarks` folder.
- In addition some of the imports are missing from `utils/scripts/benchmarks.py`. I have removed them until they will be available.