### PR TITLE
Add option to force use of pinv in LinUCB

### DIFF
--- a/pearl/neural_networks/contextual_bandit/neural_linear_regression.py
+++ b/pearl/neural_networks/contextual_bandit/neural_linear_regression.py
@@ -27,6 +27,7 @@ class NeuralLinearRegression(MuSigmaCBModel):
         hidden_dims: List[int],  # last one is the input dim for linear regression
         l2_reg_lambda_linear: float = 1.0,
         gamma: float = 1.0,
+        force_pinv: bool = False,
         output_activation_name: str = "linear",
         use_batch_norm: bool = False,
         use_layer_norm: bool = False,
@@ -46,6 +47,9 @@ class NeuralLinearRegression(MuSigmaCBModel):
             hidden_dims: size of hidden layers in the network
             l2_reg_lambda_linear: L2 regularization parameter for the linear regression layer
             gamma: discounting multiplier for the linear regression layer
+            force_pinv: If True, we will always use pseudo inverse to invert the `A` matrix. If
+                False, we will first try to use regular matrix inversion. If it fails, we will
+                fallback to pseudo inverse.
             output_activation_name: output activation function name (see ACTIVATION_MAP)
             use_batch_norm: whether to use batch normalization
             use_layer_norm: whether to use layer normalization
@@ -73,6 +77,7 @@ class NeuralLinearRegression(MuSigmaCBModel):
             feature_dim=hidden_dims[-1],
             l2_reg_lambda=l2_reg_lambda_linear,
             gamma=gamma,
+            force_pinv=force_pinv,
         )
         self.output_activation: nn.Module = ACTIVATION_MAP[output_activation_name]()
         self.linear_layer_e2e = nn.Linear(

--- a/pearl/policy_learners/contextual_bandits/linear_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/linear_bandit.py
@@ -48,6 +48,7 @@ class LinearBandit(ContextualBanditBase):
         gamma: float = 1.0,
         apply_discounting_interval: float = 0.0,  # discounting will be applied after this many
         # observations (weighted) are processed. set to 0 to disable
+        force_pinv: bool = False,  # If True, use pseudo inverse instead of regular inverse for `A`
         training_rounds: int = 100,
         batch_size: int = 128,
         action_representation_module: Optional[ActionRepresentationModule] = None,
@@ -60,7 +61,10 @@ class LinearBandit(ContextualBanditBase):
             action_representation_module=action_representation_module,
         )
         self.model = LinearRegression(
-            feature_dim=feature_dim, l2_reg_lambda=l2_reg_lambda, gamma=gamma
+            feature_dim=feature_dim,
+            l2_reg_lambda=l2_reg_lambda,
+            gamma=gamma,
+            force_pinv=force_pinv,
         )
         self.apply_discounting_interval = apply_discounting_interval
         self.last_sum_weight_when_discounted = 0.0

--- a/pearl/policy_learners/contextual_bandits/neural_linear_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/neural_linear_bandit.py
@@ -76,6 +76,7 @@ class NeuralLinearBandit(ContextualBanditBase):
         l2_reg_lambda_linear: float = 1.0,
         gamma: float = 1.0,
         apply_discounting_interval: float = 0.0,  # set to 0 to disable
+        force_pinv: bool = False,  # If True, use pseudo inverse instead of regular inverse for `A`
         state_features_only: bool = True,
         loss_type: str = "mse",  # one of the LOSS_TYPES names: [mse, mae, cross_entropy]
         output_activation_name: str = "linear",
@@ -103,6 +104,7 @@ class NeuralLinearBandit(ContextualBanditBase):
             hidden_dims=hidden_dims,
             l2_reg_lambda_linear=l2_reg_lambda_linear,
             gamma=gamma,
+            force_pinv=force_pinv,
             output_activation_name=output_activation_name,
             use_batch_norm=use_batch_norm,
             use_layer_norm=use_layer_norm,


### PR DESCRIPTION
Summary:
Adding an options to force pseudo-inverse to be used by default in LinUCB. This is useful for cases where the features are strongly correlated, so the design matrix is ill-conditioned.
The regular inverse is faster, it should be used when matrix inversion is the bottleneck and the design matrix is well-conditioned.

Reviewed By: zxpmirror1994

Differential Revision: D57462061


