### PR TITLE
refactor: add gym_space property and update GymEnvironment reset

### DIFF
--- a/pearl/utils/instantiations/environments/gym_environment.py
+++ b/pearl/utils/instantiations/environments/gym_environment.py
@@ -100,9 +100,8 @@ class GymEnvironment(Environment):
     def reset(self, seed: int | None = None) -> tuple[Observation, ActionSpace]:
         """Resets the environment and returns the initial observation and
         initial action space."""
-        # pyre-fixme: ActionSpace does not have _gym_space
-        # FIXME: private attribute _gym_space should not be accessed
-        self._action_space._gym_space.seed(seed)
+        
+        self._action_space.gym_space.seed(seed)
         self.env.action_space.seed(seed)
         reset_result = self.env.reset()
         if isinstance(reset_result, Iterable) and isinstance(reset_result[1], dict):

--- a/pearl/utils/instantiations/spaces/box.py
+++ b/pearl/utils/instantiations/spaces/box.py
@@ -104,6 +104,11 @@ class BoxSpace(Space):
         """Returns the shape of an element of the space."""
         return self.low.shape
 
+    @property
+    def gym_space(self) -> gym.Space:
+        """Returns the underlying Gymnasium space."""
+        return self._gym_space
+
     @staticmethod
     def from_gym(gym_space: gym.Space) -> BoxSpace:
         """Constructs a `BoxSpace` given a Gymnasium `Box` space.

--- a/pearl/utils/instantiations/spaces/discrete.py
+++ b/pearl/utils/instantiations/spaces/discrete.py
@@ -81,6 +81,11 @@ class DiscreteSpace(Space):
         """Returns the shape of an element of the space."""
         return self.elements[0].shape
 
+    @property
+    def gym_space(self) -> gym.Space:
+        """Returns the underlying Gymnasium space."""
+        return self._gym_space
+
     def sample(self, mask: Tensor | None = None) -> Tensor:
         """Sample an element uniformly at random from this space.
 


### PR DESCRIPTION
### Key Changes:

- Added a `gym_space` property in `BoxSpace` and `DiscreteSpace` to expose the underlying Gymnasium space.
- `BoxActionSpace` and `DiscreteActionSpace` inherit the new property.
- Modified `GymEnvironment.reset()` to call `self._action_space.gym_space.seed()` instead of accessing `_gym_space` directly.

Compiled the modified modules successfully. Succesfully ran test suite.

### Why these changes?

- Exposing a `gym_space` property provides a safe way for other components to interact with the underlying Gym space without reaching into the internal `_gym_space` attribute.
- Both `BoxActionSpace` and `DiscreteActionSpace` inherit from `BoxSpace` and `DiscreteSpace` respectively, so they automatically gain this property without modification.
- `GymEnvironment` now seeds the space through the public interface, improving encapsulation and eliminating the previous pyre-fixme comment complaining about accessing a private member.