### PR TITLE
feat: Introduced a `FlattenDictObservations` wrapper that flattens dictionary observations into a single tensor so agents can handle unusual observation shapes

### DIFF
--- a/pearl/utils/instantiations/environments/__init__.py
+++ b/pearl/utils/instantiations/environments/__init__.py
@@ -15,6 +15,7 @@ from .environments import (
     FixedNumberOfStepsEnvironment,
     ObservationTransformationEnvironmentAdapterBase,
     OneHotObservationsFromDiscrete,
+    FlattenDictObservations,
 )
 from .gym_environment import GymEnvironment
 from .reward_is_equal_to_ten_times_action_multi_arm_bandit_environment import (
@@ -36,6 +37,7 @@ __all__ = [
     "FixedNumberOfStepsEnvironment",
     "GymEnvironment",
     "OneHotObservationsFromDiscrete",
+    "FlattenDictObservations",
     "RewardIsEqualToTenTimesActionMultiArmBanditEnvironment",
     "SLCBEnvironment",
     "SparseRewardEnvironment",

--- a/pearl/utils/instantiations/environments/environments.py
+++ b/pearl/utils/instantiations/environments/environments.py
@@ -13,7 +13,7 @@ from typing import Optional, Tuple
 from pearl.api.observation import Observation
 from pearl.api.space import Space
 from pearl.utils.instantiations.spaces.discrete import DiscreteSpace
-
+from pearl.utils.instantiations.spaces.box import BoxSpace
 from pearl.utils.instantiations.spaces.discrete_action import DiscreteActionSpace
 
 try:
@@ -214,7 +214,6 @@ class FlattenDictObservations(ObservationTransformationEnvironmentAdapterBase):
             flat = FlattenDictObservations._flatten_value(example_obs)
             low = torch.full_like(flat, float("-inf"))
             high = torch.full_like(flat, float("inf"))
-        from pearl.utils.instantiations.spaces.box import BoxSpace
 
         return BoxSpace(low=low, high=high)
 

--- a/pearl/utils/instantiations/environments/environments.py
+++ b/pearl/utils/instantiations/environments/environments.py
@@ -197,7 +197,7 @@ class FlattenDictObservations(ObservationTransformationEnvironmentAdapterBase):
         if hasattr(obs_space, "spaces"):
             lows = []
             highs = []
-            for subspace in obs_space.spaces.values():  # pyre-ignore[16]
+            for key, subspace in sorted(obs_space.spaces.items()):  # pyre-ignore[16]
                 name = subspace.__class__.__name__
                 if name == "Box":
                     lows.append(torch.tensor(subspace.low).flatten())

--- a/pearl/utils/instantiations/environments/environments.py
+++ b/pearl/utils/instantiations/environments/environments.py
@@ -165,3 +165,59 @@ class OneHotObservationsFromDiscrete(ObservationTransformationEnvironmentAdapter
     @property
     def short_description(self) -> str:
         return f"One-hot observations on {self.base_environment}"
+
+
+class FlattenDictObservations(ObservationTransformationEnvironmentAdapterBase):
+    """Wraps an environment with dictionary observations and flattens them.
+
+    This adapter converts dictionary observations (for example Gymnasium's
+    ``Dict`` space) into a single 1-D tensor by concatenating the flattened
+    values of each dictionary entry.  It is useful when the rest of the agent
+    expects tensor observations.
+    """
+
+    def __init__(self, base_environment: Environment) -> None:
+        super().__init__(base_environment)
+
+    @staticmethod
+    def _flatten_value(value: object) -> torch.Tensor:
+        if isinstance(value, dict):
+            parts = [FlattenDictObservations._flatten_value(v) for k, v in sorted(value.items())]
+            return torch.cat(parts)
+        tensor_value = torch.as_tensor(value, dtype=torch.float32)
+        return tensor_value.flatten()
+
+    def compute_tensor_observation(self, observation: Observation) -> torch.Tensor:
+        assert isinstance(observation, dict), "Observation must be a dictionary"
+        return FlattenDictObservations._flatten_value(observation)
+
+    @staticmethod
+    def make_observation_space(base_environment: Environment) -> Space:
+        obs_space = base_environment.observation_space
+        if hasattr(obs_space, "spaces"):
+            lows = []
+            highs = []
+            for subspace in obs_space.spaces.values():  # pyre-ignore[16]
+                name = subspace.__class__.__name__
+                if name == "Box":
+                    lows.append(torch.tensor(subspace.low).flatten())
+                    highs.append(torch.tensor(subspace.high).flatten())
+                elif name == "Discrete":
+                    lows.append(torch.zeros(1))
+                    highs.append(torch.tensor([float(subspace.n - 1)]))
+                else:
+                    raise NotImplementedError(f"Unsupported subspace type: {name}")
+            low = torch.cat(lows).float()
+            high = torch.cat(highs).float()
+        else:
+            example_obs, _ = base_environment.reset()
+            flat = FlattenDictObservations._flatten_value(example_obs)
+            low = torch.full_like(flat, float("-inf"))
+            high = torch.full_like(flat, float("inf"))
+        from pearl.utils.instantiations.spaces.box import BoxSpace
+
+        return BoxSpace(low=low, high=high)
+
+    @property
+    def short_description(self) -> str:
+        return f"Flattened dict observations from {self.base_environment}"

--- a/test/unit/test_flatten_dict_observations.py
+++ b/test/unit/test_flatten_dict_observations.py
@@ -1,0 +1,58 @@
+import unittest
+import numpy as np
+import torch
+
+from pearl.api.action_result import ActionResult
+from pearl.api.environment import Environment
+from pearl.api.observation import Observation
+from pearl.api.action import Action
+from pearl.api.action_space import ActionSpace
+from pearl.utils.instantiations.spaces.discrete_action import DiscreteActionSpace
+from pearl.utils.instantiations.environments.environments import FlattenDictObservations
+
+try:
+    import gymnasium as gym
+except ModuleNotFoundError:  # fallback for gym
+    import gym
+
+
+class DummyDictEnv(Environment):
+    def __init__(self) -> None:
+        self._action_space = DiscreteActionSpace([torch.tensor(0), torch.tensor(1)])
+        self._observation_space = gym.spaces.Dict(
+            {
+                "x": gym.spaces.Box(low=0, high=1, shape=(2,), dtype=np.float32),
+                "y": gym.spaces.Discrete(3),
+            }
+        )
+
+    @property
+    def action_space(self) -> ActionSpace:
+        return self._action_space
+
+    @property
+    def observation_space(self) -> gym.spaces.Dict:
+        return self._observation_space
+
+    def reset(self, seed: int | None = None) -> tuple[Observation, ActionSpace]:
+        obs = {"x": np.zeros(2, dtype=np.float32), "y": 1}
+        return obs, self.action_space
+
+    def step(self, action: Action) -> ActionResult:
+        obs = {"x": np.zeros(2, dtype=np.float32), "y": 1}
+        return ActionResult(observation=obs, reward=0.0, terminated=True, truncated=False, info={})
+
+
+class TestFlattenDictObservations(unittest.TestCase):
+    def test_flatten(self) -> None:
+        env = FlattenDictObservations(DummyDictEnv())
+        obs, _ = env.reset()
+        self.assertIsInstance(obs, torch.Tensor)
+        # 2 from "x" and 1 from "y"
+        self.assertEqual(obs.shape[0], 3)
+        step_result = env.step(torch.tensor(0))
+        self.assertTrue(torch.equal(step_result.observation, obs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Key Changes:

- Implemented a `FlattenDictObservations` adapter that flattens nested dictionary observations and constructs a Box observation space in deterministic key order.
- Exposed the new dictionary observation wrapper in the environments package’s init module.
- Added unit tests covering dictionary observation flattening logic with a dummy environment.

Closes #36 