### PR TITLE
Add `later` package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "torch",
     "torchvision",
     "torchaudio",
+    "later"
 ]
 
 [project.urls]

--- a/test/unit/with_pytorch/test_serialization.py
+++ b/test/unit/with_pytorch/test_serialization.py
@@ -6,8 +6,9 @@ import io
 
 import torch
 from later.unittest import TestCase
-from pearl.test.unit.with_pytorch.test_agent import TestAgentWithPyTorch
 from torch import nn
+
+from .test_agent import TestAgentWithPyTorch
 
 
 def save_and_load_state_dict(origin: nn.Module, destination: nn.Module) -> None:


### PR DESCRIPTION
Summary:
`later.unittest.TestCase` is now the recommended unit test class to use.

This corrects the absence of `later` in `pyproject.toml`.

It also changes an import from absolute to relative in `test_serialization.py` because that creates an error in the MacOS execution. See discussion in https://github.com/facebookresearch/Pearl/pull/116.

Differential Revision: D78047067


