### PR TITLE
patch: minor fix in q value networks

### DIFF
--- a/pearl/neural_networks/sequential_decision_making/q_value_networks.py
+++ b/pearl/neural_networks/sequential_decision_making/q_value_networks.py
@@ -912,7 +912,7 @@ class CNNQValueMultiHeadNetwork(QValueNetwork):
             q_values,  # (batch_size x num actions x 1)
         )  # (batch_size x number_of_actions_to_query x 1)
         q_values = q_values.squeeze(-1)  # (batch_size x number_of_actions_to_query)
-        return q_values if len(action_batch) == 3 else q_values.squeeze(-1)
+        return q_values if len(action_batch.shape) == 3 else q_values.squeeze(-1)
 
     @property
     def state_dim(self) -> int:


### PR DESCRIPTION
Change:
- The `CNNQValueMultiHeadNetwork.get_q_values` method now checks `len(action_batch.shape)` when deciding whether to squeeze the returned tensor instead of using `len(action_batch)`.

Why?
- The previous logic misinterpreted a 3‑D action tensor: `len(action_batch)` returned the batch size rather than the number of dimensions, causing incorrect squeezing behavior and potentially wrong output shapes.