### PR TITLE
refactor: refinements in utils and associated functions

### DIFF
--- a/pearl/neural_networks/common/epistemic_neural_networks.py
+++ b/pearl/neural_networks/common/epistemic_neural_networks.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from pearl.neural_networks.common.utils import init_weights, mlp_block
+from pearl.neural_networks.common.utils import xavier_init_weights, mlp_block
 from torch import Tensor
 
 
@@ -155,12 +155,12 @@ class Priornet(nn.Module):
         for _ in range(self.index_dim):
             model = mlp_block(self.input_dim, self.hidden_dims, self.output_dim)
             # Xavier uniform initalization
-            model.apply(init_weights)
+            model.apply(xavier_init_weights)
             models.append(model)
         self.base_model: nn.Module = mlp_block(
             self.input_dim, self.hidden_dims, self.output_dim
         )
-        self.base_model.apply(init_weights)
+        self.base_model.apply(xavier_init_weights)
         self.base_model = self.base_model.to("meta")
         self.models: nn.ModuleList = nn.ModuleList(models)
 
@@ -228,7 +228,7 @@ class Epinet(EpistemicNeuralNetwork):
         self.epinet: nn.Module = mlp_block(
             epinet_input_dim, self.epi_hiddens, self.index_dim * self.output_dim
         )
-        self.epinet.apply(init_weights)
+        self.epinet.apply(xavier_init_weights)
         # Priornet
         self.priornet = Priornet(
             self.input_dim, self.prior_hiddens, self.output_dim, self.index_dim

--- a/pearl/neural_networks/contextual_bandit/neural_linear_regression.py
+++ b/pearl/neural_networks/contextual_bandit/neural_linear_regression.py
@@ -12,7 +12,7 @@ from typing import List
 
 import torch
 import torch.nn as nn
-from pearl.neural_networks.common.utils import ACTIVATION_MAP
+from pearl.neural_networks.common.utils import ActivationType
 from pearl.neural_networks.common.value_networks import VanillaValueNetwork
 from pearl.neural_networks.contextual_bandit.base_cb_model import MuSigmaCBModel
 from pearl.neural_networks.contextual_bandit.linear_regression import LinearRegression
@@ -51,7 +51,7 @@ class NeuralLinearRegression(MuSigmaCBModel):
             force_pinv: If True, we will always use pseudo inverse to invert the `A` matrix. If
                 False, we will first try to use regular matrix inversion. If it fails, we will
                 fallback to pseudo inverse.
-            output_activation_name: output activation function name (see ACTIVATION_MAP)
+            output_activation_name: output activation function name (see ActivationType)
             use_batch_norm: whether to use batch normalization
             use_layer_norm: whether to use layer normalization
             hidden_activation: activation function for hidden layers
@@ -80,7 +80,7 @@ class NeuralLinearRegression(MuSigmaCBModel):
             gamma=gamma,
             force_pinv=force_pinv,
         )
-        self.output_activation: nn.Module = ACTIVATION_MAP[output_activation_name]()
+        self.output_activation: nn.Module = ActivationType(output_activation_name).module()
         self.linear_layer_e2e = nn.Linear(
             in_features=hidden_dims[-1], out_features=1, bias=False
         )  # used only if nn_e2e is True

--- a/pearl/neural_networks/sequential_decision_making/twin_critic.py
+++ b/pearl/neural_networks/sequential_decision_making/twin_critic.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from pearl.neural_networks.common.utils import init_weights
+from pearl.neural_networks.common.utils import xavier_init_weights
 from pearl.neural_networks.sequential_decision_making.q_value_networks import (
     QValueNetwork,
     VanillaQValueNetwork,
@@ -34,7 +34,7 @@ class TwinCritic(torch.nn.Module):
         state_dim: Optional[int] = None,
         action_dim: Optional[int] = None,
         hidden_dims: Optional[Iterable[int]] = None,
-        init_fn: Callable[[nn.Module], None] = init_weights,
+        init_fn: Callable[[nn.Module], None] = xavier_init_weights,
         network_type: type[QValueNetwork] = VanillaQValueNetwork,
         output_dim: int = 1,
         network_instance_1: Optional[QValueNetwork] = None,

--- a/pearl/policy_learners/contextual_bandits/neural_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/neural_bandit.py
@@ -21,7 +21,7 @@ from pearl.history_summarization_modules.history_summarization_module import (
     HistorySummarizationModule,
     SubjectiveState,
 )
-from pearl.neural_networks.common.utils import LOSS_TYPES
+from pearl.neural_networks.common.utils import LossType
 from pearl.neural_networks.common.value_networks import VanillaValueNetwork
 from pearl.policy_learners.contextual_bandits.contextual_bandit_base import (
     ContextualBanditBase,
@@ -58,7 +58,7 @@ class NeuralBandit(ContextualBanditBase):
         batch_size: int = 128,
         learning_rate: float = 0.001,
         state_features_only: bool = False,
-        loss_type: str = "mse",  # one of the LOSS_TYPES names, e.g., mse, mae, xentropy
+        loss_type: LossType | str = LossType.MSE,  # one of the LossType names, e.g., MSE, MAE, CROSS_ENTROPY
         action_representation_module: ActionRepresentationModule | None = None,
     ) -> None:
         super().__init__(
@@ -77,7 +77,7 @@ class NeuralBandit(ContextualBanditBase):
             self.model.parameters(), lr=learning_rate, amsgrad=True
         )
         self._state_features_only = state_features_only
-        self.loss_type = loss_type
+        self.loss_type = LossType(loss_type) if isinstance(loss_type, str) else loss_type
 
     def learn_batch(self, batch: TransitionBatch) -> dict[str, Any]:
         expected_values = batch.reward
@@ -94,7 +94,7 @@ class NeuralBandit(ContextualBanditBase):
         # forward pass
         predicted_values = self.model(input_features)
 
-        criterion = LOSS_TYPES[self.loss_type]
+        criterion = self.loss_type.function()
 
         # don't reduce the loss, so that we can calculate weighted loss
         loss = criterion(

--- a/pearl/policy_learners/sequential_decision_making/actor_critic_base.py
+++ b/pearl/policy_learners/sequential_decision_making/actor_critic_base.py
@@ -24,7 +24,7 @@ from pearl.api.state import SubjectiveState
 from pearl.history_summarization_modules.history_summarization_module import (
     HistorySummarizationModule,
 )
-from pearl.neural_networks.common.utils import init_weights, update_target_network
+from pearl.neural_networks.common.utils import xavier_init_weights, update_target_network
 from pearl.neural_networks.common.value_networks import ValueNetwork
 from pearl.neural_networks.sequential_decision_making.actor_networks import (
     ActorNetwork,
@@ -154,7 +154,7 @@ class ActorCriticBase(PolicyLearner):
                 ),
                 action_space=action_space,
             )
-        self._actor.apply(init_weights)
+        self._actor.apply(xavier_init_weights)
         if actor_optimizer is not None:
             self._actor_optimizer: optim.Optimizer = actor_optimizer
         else:

--- a/pearl/utils/functional_utils/learning/critic_utils.py
+++ b/pearl/utils/functional_utils/learning/critic_utils.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 
 from pearl.neural_networks.common.utils import (
-    init_weights,
+    xavier_init_weights,
     update_target_network,
     update_target_networks,
 )
@@ -81,7 +81,7 @@ def make_critic(
             action_dim=action_dim,
             hidden_dims=hidden_dims,
             network_type=network_type,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
     else:
         if network_type == VanillaQValueNetwork:

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from pearl.neural_networks.common.utils import init_weights
+from pearl.neural_networks.common.utils import xavier_init_weights
 from pearl.neural_networks.common.value_networks import VanillaValueNetwork
 from pearl.neural_networks.sequential_decision_making.actor_networks import (
     GaussianActorNetwork,
@@ -602,7 +602,7 @@ class TestIntegration(unittest.TestCase):
             action_dim=action_representation_module.max_number_actions,
             hidden_dims=[64, 64, 64],
             network_type=VanillaQValueNetwork,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
 
         agent = PearlAgent(
@@ -692,7 +692,7 @@ class TestIntegration(unittest.TestCase):
             action_dim=env.action_space.action_dim,
             hidden_dims=[64, 64],
             network_type=VanillaQValueNetwork,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
 
         agent = PearlAgent(
@@ -861,7 +861,7 @@ class TestIntegration(unittest.TestCase):
             action_dim=env.action_space.action_dim,
             hidden_dims=[400, 300],
             network_type=VanillaQValueNetwork,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
 
         agent = PearlAgent(

--- a/test/unit/with_pytorch/test_agent.py
+++ b/test/unit/with_pytorch/test_agent.py
@@ -23,7 +23,7 @@ from pearl.api.environment import Environment
 from pearl.history_summarization_modules.lstm_history_summarization_module import (
     LSTMHistorySummarizationModule,
 )
-from pearl.neural_networks.common.utils import init_weights
+from pearl.neural_networks.common.utils import xavier_init_weights
 from pearl.neural_networks.common.value_networks import VanillaValueNetwork
 from pearl.neural_networks.sequential_decision_making.actor_networks import (
     GaussianActorNetwork,
@@ -696,7 +696,7 @@ class TestAgentWithPyTorch(unittest.TestCase):
             action_dim=action_representation_module.max_number_actions,
             hidden_dims=[64, 64, 64],
             network_type=VanillaQValueNetwork,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
 
         agent = PearlAgent(
@@ -777,7 +777,7 @@ class TestAgentWithPyTorch(unittest.TestCase):
             action_dim=env.action_space.action_dim,
             hidden_dims=[64, 64],
             network_type=VanillaQValueNetwork,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
 
         agent = PearlAgent(
@@ -977,7 +977,7 @@ class TestAgentWithPyTorch(unittest.TestCase):
             action_dim=env.action_space.action_dim,
             hidden_dims=[400, 300],
             network_type=VanillaQValueNetwork,
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
 
         agent = PearlAgent(

--- a/test/unit/with_pytorch/test_compare.py
+++ b/test/unit/with_pytorch/test_compare.py
@@ -31,6 +31,7 @@ from pearl.neural_networks.contextual_bandit.neural_linear_regression import (
 from pearl.neural_networks.sequential_decision_making.q_value_networks import (
     EnsembleQValueNetwork,
 )
+from pearl.neural_networks.common.utils import LossType
 from pearl.policy_learners.contextual_bandits.contextual_bandit_base import (
     ContextualBanditBase,
 )
@@ -478,7 +479,7 @@ class TestCompare(TestCase):
             feature_dim=10,
             hidden_dims=[32, 16],
             exploration_module=exploration_module1,
-            loss_type="mse",
+            loss_type=LossType.MSE,
             apply_discounting_interval=100,
         )
         torch.manual_seed(0)  # Reset the seed for the second module
@@ -486,7 +487,7 @@ class TestCompare(TestCase):
             feature_dim=10,
             hidden_dims=[32, 16],
             exploration_module=exploration_module2,
-            loss_type="mse",
+            loss_type=LossType.MSE,
             apply_discounting_interval=100,
         )
 
@@ -497,7 +498,7 @@ class TestCompare(TestCase):
         self.assertEqual(module1.compare(module2), "")
 
         # Modify an attribute of module2 to create a difference
-        module2.loss_type = "mae"
+        module2.loss_type = LossType.MAE
 
         # Now the comparison should show a difference
         self.assertNotEqual(module1.compare(module2), "")
@@ -699,13 +700,13 @@ class TestCompare(TestCase):
             feature_dim=10,
             hidden_dims=[32, 16],
             exploration_module=exploration_module1,
-            loss_type="mse",
+            loss_type=LossType.MSE,
         )
         module2 = NeuralBandit(
             feature_dim=10,
             hidden_dims=[32, 16],
             exploration_module=exploration_module2,
-            loss_type="mse",
+            loss_type=LossType.MSE,
         )
 
         # Compare module1 with itself
@@ -724,7 +725,7 @@ class TestCompare(TestCase):
         self.assertEqual(module1.compare(module2), "")
 
         # Modify an attribute of module2 to create a difference
-        module2.loss_type = "mae"
+        module2.loss_type = LossType.MAE
 
         # Now the comparison should show a difference
         self.assertNotEqual(module1.compare(module2), "")

--- a/test/unit/with_pytorch/test_deep_td_learning.py
+++ b/test/unit/with_pytorch/test_deep_td_learning.py
@@ -14,7 +14,7 @@ import torch
 from pearl.action_representation_modules.one_hot_action_representation_module import (
     OneHotActionTensorRepresentationModule,
 )
-from pearl.neural_networks.common.utils import init_weights
+from pearl.neural_networks.common.utils import xavier_init_weights
 from pearl.policy_learners.exploration_modules.common.epsilon_greedy_exploration import (
     EGreedyExploration,
 )
@@ -78,8 +78,8 @@ class TestDeepTDLearning(unittest.TestCase):
             # 10 should be large enough to see difference.
             batch1 = double_dqn.preprocess_batch(copy.deepcopy(self.batch))
             batch2 = dqn.preprocess_batch(copy.deepcopy(self.batch))
-            double_dqn._Q.apply(init_weights)
-            double_dqn._Q_target.apply(init_weights)
+            double_dqn._Q.apply(xavier_init_weights)
+            double_dqn._Q_target.apply(xavier_init_weights)
             double_value = double_dqn.get_next_state_values(batch1, self.batch_size)
 
             dqn._Q.load_state_dict(double_dqn._Q.state_dict())

--- a/test/unit/with_pytorch/test_neural_linear_bandits.py
+++ b/test/unit/with_pytorch/test_neural_linear_bandits.py
@@ -12,7 +12,7 @@ import unittest
 import torch
 import torch.testing as tt
 from pearl.neural_networks.common.residual_wrapper import ResidualWrapper
-from pearl.policy_learners.contextual_bandits.neural_bandit import LOSS_TYPES
+from pearl.neural_networks.common.utils import LossType
 from pearl.policy_learners.contextual_bandits.neural_linear_bandit import (
     NeuralLinearBandit,
 )
@@ -103,8 +103,8 @@ class TestNeuralLinearBandits(unittest.TestCase):
     # currently test support mse, mae, cross_entropy
     # separate loss_types into inddividual test cases to make it easier to debug.
     def test_neural_linucb_mse_loss(self) -> None:
-        for loss_type in list(LOSS_TYPES.keys()):
-            if loss_type == "mse":
+        for loss_type in list(LossType):
+            if loss_type is LossType.MSE:
                 self.neural_linucb(
                     loss_type=loss_type,
                     epochs=NUM_EPOCHS,
@@ -112,8 +112,8 @@ class TestNeuralLinearBandits(unittest.TestCase):
                 )
 
     def test_neural_linucb_mae_loss(self) -> None:
-        for loss_type in list(LOSS_TYPES.keys()):
-            if loss_type == "mae":
+        for loss_type in list(LossType):
+            if loss_type is LossType.MAE:
                 self.neural_linucb(
                     loss_type=loss_type,
                     epochs=NUM_EPOCHS,
@@ -121,8 +121,8 @@ class TestNeuralLinearBandits(unittest.TestCase):
                 )
 
     def test_neural_linucb_cross_entropy_loss(self) -> None:
-        for loss_type in list(LOSS_TYPES.keys()):
-            if loss_type == "cross_entropy":
+        for loss_type in list(LossType):
+            if loss_type is LossType.CROSS_ENTROPY:
                 self.neural_linucb(
                     loss_type=loss_type,
                     epochs=NUM_EPOCHS,
@@ -130,7 +130,7 @@ class TestNeuralLinearBandits(unittest.TestCase):
                 )
 
     def neural_linucb(
-        self, loss_type: str, epochs: int, output_activation_name: str
+        self, loss_type: LossType, epochs: int, output_activation_name: str
     ) -> None:
         feature_dim = 15  # It is important to keep this different from hidden_dims
         batch_size = feature_dim * 4  # It is important to have enough data for training
@@ -172,11 +172,11 @@ class TestNeuralLinearBandits(unittest.TestCase):
 
         if epochs >= NUM_EPOCHS:
             self.assertTrue(all(not torch.isnan(x) for x in losses))
-            if loss_type == "mse":
+            if loss_type is LossType.MSE:
                 self.assertGreater(1e-1, losses[-1])
-            elif loss_type == "mae":
+            elif loss_type is LossType.MAE:
                 self.assertGreater(1e-1, losses[-1] ** 2)  # turn mae into mse
-            elif loss_type == "cross_entropy":
+            elif loss_type is LossType.CROSS_ENTROPY:
                 # cross_entropy (BCE) does not guarantee train loss to 0+ when labels are not 0/1
                 self.assertTrue(
                     losses[-1] < losses[0], "training loss should be decreasing"

--- a/test/unit/with_pytorch/test_twin_critic.py
+++ b/test/unit/with_pytorch/test_twin_critic.py
@@ -10,7 +10,7 @@
 import unittest
 
 import torch
-from pearl.neural_networks.common.utils import init_weights
+from pearl.neural_networks.common.utils import xavier_init_weights
 from pearl.neural_networks.sequential_decision_making.twin_critic import TwinCritic
 from pearl.utils.functional_utils.learning.critic_utils import (
     twin_critic_action_value_loss,
@@ -28,7 +28,7 @@ class TestTwinCritic(unittest.TestCase):
             state_dim=self.state_dim,
             action_dim=self.action_dim,
             hidden_dims=[10, 10],
-            init_fn=init_weights,
+            init_fn=xavier_init_weights,
         )
         state_batch = torch.randn(self.batch_size, self.state_dim)
         action_batch = torch.randn(self.batch_size, self.action_dim)


### PR DESCRIPTION
Changes:
- Replaced activation and loss dictionaries with Enum classes `ActivationType` and `LossType` for type safety.
- Replaced the old initialization helper with a clearer `xavier_init_weights` function for linear layers.
- Neural linear regression selects its output activation via `ActivationType` for clarity.
- Rewrote the normalized Softplus activation to avoid redundant computations and added a default Softmax dimension for the activation map.
- Fixed the convolution block to apply batch normalization using the correct output channel size.
- Neural bandit classes accept LossType parameters and call loss_type.function() when training.

Why these changes?
- Mostly mentioned in TODOs in `utils.py` i.e. (Enums and `xavier_init_weights`), so decided to refactor according to it.
- MLP construction now instantiates activations through the enums, reducing string lookups.