### PR TITLE
fix: corrected `NeuralBandit`, `TensorBasedReplayBuffer` and import path in `test_serialization` for code-coverage in CI/CD

### DIFF
--- a/pearl/policy_learners/contextual_bandits/neural_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/neural_bandit.py
@@ -132,12 +132,12 @@ class NeuralBandit(ContextualBanditBase):
         """
         Args:
             subjective_state: state will be applied to different action vectors in action_space
-            action_space: contains a list of action vector, currenly only support static space
+            action_space: contains a list of action vector, currently only support static space
         Return:
             action index chosen given state and action vectors
         """
         assert isinstance(available_action_space, DiscreteActionSpace)
-        # It doesnt make sense to call act if we are not working with action vector
+        # It doesn't make sense to call act if we are not working with action vector
         action_count = available_action_space.n
         new_feature = concatenate_actions_to_state(
             subjective_state=subjective_state,
@@ -145,7 +145,14 @@ class NeuralBandit(ContextualBanditBase):
             state_features_only=self._state_features_only,
             action_representation_module=self.action_representation_module,
         )
-        values = self.model(new_feature).squeeze(-1)
+        batch_size = new_feature.shape[0]
+        feature_dim = new_feature.shape[-1]
+        # Flatten the action dimension before model evaluation
+        values = (
+            self.model(new_feature.reshape(-1, feature_dim))
+            .reshape(batch_size, -1)
+            .squeeze(-1)
+        )
         # batch_size * action_count
         assert values.numel() == new_feature.shape[0] * action_count
         return self.exploration_module.act(

--- a/pearl/policy_learners/contextual_bandits/neural_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/neural_bandit.py
@@ -132,7 +132,7 @@ class NeuralBandit(ContextualBanditBase):
         """
         Args:
             subjective_state: state will be applied to different action vectors in action_space
-            action_space: contains a list of action vector, currently only support static space
+            action_space: contains a list of action vector, currenly only support static space
         Return:
             action index chosen given state and action vectors
         """
@@ -145,14 +145,7 @@ class NeuralBandit(ContextualBanditBase):
             state_features_only=self._state_features_only,
             action_representation_module=self.action_representation_module,
         )
-        batch_size = new_feature.shape[0]
-        feature_dim = new_feature.shape[-1]
-        # Flatten the action dimension before model evaluation
-        values = (
-            self.model(new_feature.reshape(-1, feature_dim))
-            .reshape(batch_size, -1)
-            .squeeze(-1)
-        )
+        values = self.model(new_feature).squeeze(-1)
         # batch_size * action_count
         assert values.numel() == new_feature.shape[0] * action_count
         return self.exploration_module.act(

--- a/pearl/policy_learners/contextual_bandits/neural_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/neural_bandit.py
@@ -132,7 +132,7 @@ class NeuralBandit(ContextualBanditBase):
         """
         Args:
             subjective_state: state will be applied to different action vectors in action_space
-            action_space: contains a list of action vector, currenly only support static space
+            action_space: contains a list of action vector, currently only support static space
         Return:
             action index chosen given state and action vectors
         """
@@ -145,7 +145,14 @@ class NeuralBandit(ContextualBanditBase):
             state_features_only=self._state_features_only,
             action_representation_module=self.action_representation_module,
         )
-        values = self.model(new_feature).squeeze(-1)
+        batch_size = new_feature.shape[0]
+        feature_dim = new_feature.shape[-1]
+        # Flatten the action dimension before model evaluation
+        values = (
+            self.model(new_feature.reshape(-1, feature_dim))
+            .reshape(batch_size, -1)
+            .squeeze(-1)
+        )
         # batch_size * action_count
         assert values.numel() == new_feature.shape[0] * action_count
         return self.exploration_module.act(

--- a/pearl/replay_buffers/tensor_based_replay_buffer.py
+++ b/pearl/replay_buffers/tensor_based_replay_buffer.py
@@ -161,9 +161,12 @@ class TensorBasedReplayBuffer(ReplayBuffer):
 
     def _process_single_action(self, action: Action) -> torch.Tensor:
         if isinstance(action, torch.Tensor):
-            return action.to(get_default_device()).clone().detach().unsqueeze(0)
+            tensor = action.to(get_default_device()).clone().detach()
         else:
-            return torch.tensor(action).unsqueeze(0)
+            tensor = torch.tensor(action)
+        if tensor.ndim == 0:
+            tensor = tensor.unsqueeze(0)
+        return tensor
 
     def _process_single_reward(self, reward: Reward) -> torch.Tensor:
         return torch.tensor([reward])

--- a/pearl/replay_buffers/tensor_based_replay_buffer.py
+++ b/pearl/replay_buffers/tensor_based_replay_buffer.py
@@ -161,9 +161,12 @@ class TensorBasedReplayBuffer(ReplayBuffer):
 
     def _process_single_action(self, action: Action) -> torch.Tensor:
         if isinstance(action, torch.Tensor):
-            return action.to(get_default_device()).clone().detach().unsqueeze(0)
+            tensor = action.to(get_default_device()).clone().detach()
         else:
-            return torch.tensor(action).unsqueeze(0)
+            tensor = torch.tensor(action)
+        if tensor.ndim <= 1:
+            tensor = tensor.unsqueeze(0)
+        return tensor
 
     def _process_single_reward(self, reward: Reward) -> torch.Tensor:
         return torch.tensor([reward])

--- a/pearl/replay_buffers/tensor_based_replay_buffer.py
+++ b/pearl/replay_buffers/tensor_based_replay_buffer.py
@@ -161,12 +161,9 @@ class TensorBasedReplayBuffer(ReplayBuffer):
 
     def _process_single_action(self, action: Action) -> torch.Tensor:
         if isinstance(action, torch.Tensor):
-            tensor = action.to(get_default_device()).clone().detach()
+            return action.to(get_default_device()).clone().detach().unsqueeze(0)
         else:
-            tensor = torch.tensor(action)
-        if tensor.ndim == 0:
-            tensor = tensor.unsqueeze(0)
-        return tensor
+            return torch.tensor(action).unsqueeze(0)
 
     def _process_single_reward(self, reward: Reward) -> torch.Tensor:
         return torch.tensor([reward])

--- a/test/unit/with_pytorch/test_serialization.py
+++ b/test/unit/with_pytorch/test_serialization.py
@@ -6,7 +6,7 @@ import io
 from unittest import TestCase
 
 import torch
-from pearl.test.unit.with_pytorch.test_agent import TestAgentWithPyTorch
+from test.unit.with_pytorch.test_agent import TestAgentWithPyTorch
 from torch import nn
 
 


### PR DESCRIPTION
Change:
- Updated import path from `from pearl.test.unit.with_pytorch.test_agent import TestAgentWithPyTorch` to `from test.unit.with_pytorch.test_agent import TestAgentWithPyTorch` fixing code-coverage issue in CI/CD.
- Since `test` folder is outside `pearl`, it makes sense.
<img width="206" height="243" alt="image" src="https://github.com/user-attachments/assets/e31b91dd-c5d5-4ac4-be42-efa3e4a7be7e" />

Why?
<img width="802" height="471" alt="image" src="https://github.com/user-attachments/assets/59db1ad8-8b5f-49dc-99d5-9d273bb385fb" />
