### PR TITLE
fix: squeeze 3D action tensor in LinUCB learn_batch

### DIFF
--- a/pearl/policy_learners/contextual_bandits/linear_bandit.py
+++ b/pearl/policy_learners/contextual_bandits/linear_bandit.py
@@ -150,7 +150,7 @@ class LinearBandit(ContextualBanditBase):
             if batch.weight is not None
             else torch.ones_like(expected_values)
         )
-        x = torch.cat([batch.state, batch.action], dim=1)
+        x = torch.cat([batch.state, torch.squeeze(batch.action, dim=1)], dim=1)
         self.model.learn_batch(
             x=x,
             y=batch.reward,


### PR DESCRIPTION
## Problem

When running the contextual_bandits_tutorial with LinUCB, training fails due to tensor dimension mismatch:
- `batch.state` shape: `[1, 16]`
- `batch.action` shape: `[1, 1, 10]` (one-hot encoded, 3D)

`torch.cat([batch.state, batch.action], dim=1)` fails because state is 2D but action is 3D.

## Fix

Added `torch.squeeze(batch.action, dim=1)` to handle 3D action tensors. This safely converts `[B, 1, N]` → `[B, N]` while leaving already-2D `[B, N]` tensors unchanged (squeeze is a no-op when dim=1 has size > 1).

Fixes #125