### PR TITLE
Support Tuple observations in GymEnvironment

### DIFF
--- a/pearl/utils/instantiations/environments/gym_environment.py
+++ b/pearl/utils/instantiations/environments/gym_environment.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable
 from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
+import torch
 from pearl.api.action import Action
 from pearl.api.action_result import ActionResult
 from pearl.api.action_space import ActionSpace
@@ -80,10 +81,12 @@ class GymEnvironment(Environment):
             env = env_or_env_name
         # pyrefly: ignore [bad-assignment]
         self.env: gym.Env = env
-        self._action_space: ActionSpace = _get_pearl_space(
+        self._flatten_tuple_observations = (
+            self.env.observation_space.__class__.__name__ == "Tuple"
+        )
+        self._action_space: ActionSpace = _get_pearl_action_space(
             # pyrefly: ignore [bad-argument-type]
             gym_space=self.env.action_space,
-            gym_to_pearl_map=GYM_TO_PEARL_ACTION_SPACE,
         )
         self._observation_space: Space = _get_pearl_space(
             # pyrefly: ignore [bad-argument-type]
@@ -118,9 +121,7 @@ class GymEnvironment(Environment):
             # TODO: Deprecate this part at some point and only support new
             # version of Gymnasium?
             observation = list(reset_result.values())[0]  # pyre-ignore
-        if isinstance(observation, np.ndarray) and observation.dtype == np.float64:
-            observation = observation.astype(np.float32)
-        return observation, self.action_space
+        return self._process_observation(observation), self.action_space
 
     def step(self, action: Action) -> ActionResult:
         """Takes one step in the environment given the agent's action. Returns an
@@ -160,8 +161,7 @@ class GymEnvironment(Environment):
         else:
             available_action_space = None
 
-        if isinstance(observation, np.ndarray) and observation.dtype == np.float64:
-            observation = observation.astype(np.float32)
+        observation = self._process_observation(observation)
         if isinstance(reward, np.float64):
             reward = reward.astype(np.float32)
         if isinstance(cost, np.float64):
@@ -182,6 +182,13 @@ class GymEnvironment(Environment):
 
     def close(self) -> None:
         self.env.close()
+
+    def _process_observation(self, observation: Observation) -> Observation:
+        if self._flatten_tuple_observations:
+            return _flatten_tuple_observation(observation)
+        if isinstance(observation, np.ndarray) and observation.dtype == np.float64:
+            return observation.astype(np.float32)
+        return observation
 
     def __str__(self) -> str:
         if self.env.spec is not None:
@@ -209,9 +216,14 @@ def _get_gym_action(
 
 def _get_pearl_space(
     gym_space: gym.Space, gym_to_pearl_map: dict[str, Any]
-) -> ActionSpace:
-    """Returns the Pearl action space for this environment."""
+) -> Space:
+    """Returns the Pearl space for this environment."""
     gym_space_name = gym_space.__class__.__name__
+    if (
+        gym_space_name == "Tuple"
+        and gym_to_pearl_map is GYM_TO_PEARL_OBSERVATION_SPACE
+    ):
+        return _tuple_observation_space_to_box_space(gym_space)
     try:
         pearl_action_space_cls = gym_to_pearl_map[gym_space_name]
     except KeyError:
@@ -219,3 +231,59 @@ def _get_pearl_space(
             f"The Gym space '{gym_space_name}' is not yet supported in Pearl."
         )
     return pearl_action_space_cls.from_gym(gym_space)
+
+
+def _get_pearl_action_space(gym_space: gym.Space) -> ActionSpace:
+    space = _get_pearl_space(
+        gym_space=gym_space,
+        gym_to_pearl_map=GYM_TO_PEARL_ACTION_SPACE,
+    )
+    assert isinstance(space, ActionSpace)
+    return space
+
+
+def _flatten_tuple_observation(observation: Observation) -> torch.Tensor:
+    assert isinstance(observation, tuple), "Observation must be a tuple"
+    return torch.cat([_flatten_observation_value(value) for value in observation])
+
+
+def _flatten_observation_value(value: object) -> torch.Tensor:
+    if isinstance(value, tuple):
+        return torch.cat([_flatten_observation_value(v) for v in value])
+    return torch.as_tensor(value, dtype=torch.float32).flatten()
+
+
+def _tuple_observation_space_to_box_space(gym_space: gym.Space) -> BoxSpace:
+    lows = []
+    highs = []
+    for subspace in gym_space.spaces:  # pyre-ignore[16]
+        low, high = _space_bounds(subspace)
+        lows.append(low)
+        highs.append(high)
+    return BoxSpace(low=torch.cat(lows).float(), high=torch.cat(highs).float())
+
+
+def _space_bounds(gym_space: gym.Space) -> tuple[torch.Tensor, torch.Tensor]:
+    gym_space_name = gym_space.__class__.__name__
+    if gym_space_name == "Box":
+        return (
+            torch.as_tensor(gym_space.low).flatten(),  # pyre-ignore[16]
+            torch.as_tensor(gym_space.high).flatten(),  # pyre-ignore[16]
+        )
+    if gym_space_name == "Discrete":
+        start = float(getattr(gym_space, "start", 0))
+        return (
+            torch.tensor([start]),
+            torch.tensor([start + float(gym_space.n) - 1]),  # pyre-ignore[16]
+        )
+    if gym_space_name == "Tuple":
+        lows = []
+        highs = []
+        for subspace in gym_space.spaces:  # pyre-ignore[16]
+            low, high = _space_bounds(subspace)
+            lows.append(low)
+            highs.append(high)
+        return torch.cat(lows), torch.cat(highs)
+    raise NotImplementedError(
+        f"Unsupported Tuple observation subspace type: {gym_space_name}"
+    )

--- a/test/unit/test_gym_environment.py
+++ b/test/unit/test_gym_environment.py
@@ -1,0 +1,144 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+# pyre-strict
+
+import unittest
+from typing import Any
+
+import numpy as np
+import torch
+from pearl.utils.instantiations.environments.gym_environment import GymEnvironment
+from pearl.utils.instantiations.spaces.box import BoxSpace
+
+try:
+    import gymnasium as gym
+except ModuleNotFoundError:
+    import gym
+
+
+class MixedTupleObservationEnv(gym.Env):
+    def __init__(self) -> None:
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Tuple(
+            (
+                gym.spaces.Discrete(3, start=1),
+                gym.spaces.Box(
+                    low=np.array([-1.0, 0.0], dtype=np.float32),
+                    high=np.array([1.0, 2.0], dtype=np.float32),
+                ),
+                gym.spaces.Tuple(
+                    (
+                        gym.spaces.Discrete(2),
+                        gym.spaces.Box(
+                            low=np.array([5.0], dtype=np.float32),
+                            high=np.array([6.0], dtype=np.float32),
+                        ),
+                    )
+                ),
+            )
+        )
+
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[tuple[object, ...], dict[str, Any]]:
+        super().reset(seed=seed)
+        return (2, np.array([0.25, 1.5], dtype=np.float32), (1, np.array([5.5]))), {}
+
+    def step(
+        self, action: int
+    ) -> tuple[tuple[object, ...], float, bool, bool, dict[str, Any]]:
+        return (
+            (1, np.array([-0.5, 0.5], dtype=np.float32), (0, np.array([6.0]))),
+            1.0,
+            True,
+            False,
+            {},
+        )
+
+
+class TupleActionEnv(gym.Env):
+    def __init__(self) -> None:
+        self.action_space = gym.spaces.Tuple(
+            (gym.spaces.Discrete(2), gym.spaces.Discrete(3))
+        )
+        self.observation_space = gym.spaces.Box(
+            low=np.array([0.0], dtype=np.float32),
+            high=np.array([1.0], dtype=np.float32),
+        )
+
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        super().reset(seed=seed)
+        return np.array([0.0], dtype=np.float32), {}
+
+    def step(
+        self, action: tuple[int, int]
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        return np.array([0.0], dtype=np.float32), 0.0, True, False, {}
+
+
+class TestGymEnvironment(unittest.TestCase):
+    def test_blackjack_tuple_observations_are_flattened(self) -> None:
+        env = GymEnvironment("Blackjack-v1")
+
+        self.assertIsInstance(env.observation_space, BoxSpace)
+        self.assertEqual(env.observation_space.shape, torch.Size([3]))
+        torch.testing.assert_close(
+            env.observation_space.low, torch.tensor([0.0, 0.0, 0.0])
+        )
+        torch.testing.assert_close(
+            env.observation_space.high, torch.tensor([31.0, 10.0, 1.0])
+        )
+
+        observation, action_space = env.reset(seed=0)
+        self.assertIs(action_space, env.action_space)
+        self.assertIsInstance(observation, torch.Tensor)
+        self.assertEqual(observation.shape, torch.Size([3]))
+
+        action_result = env.step(torch.tensor(0))
+        self.assertIsInstance(action_result.observation, torch.Tensor)
+        self.assertEqual(action_result.observation.shape, torch.Size([3]))
+
+    def test_mixed_tuple_observation_space_bounds_and_values_are_flattened(
+        self,
+    ) -> None:
+        env = GymEnvironment(MixedTupleObservationEnv())
+
+        self.assertIsInstance(env.observation_space, BoxSpace)
+        torch.testing.assert_close(
+            env.observation_space.low,
+            torch.tensor([1.0, -1.0, 0.0, 0.0, 5.0]),
+        )
+        torch.testing.assert_close(
+            env.observation_space.high,
+            torch.tensor([3.0, 1.0, 2.0, 1.0, 6.0]),
+        )
+
+        observation, _ = env.reset(seed=0)
+        self.assertIsInstance(observation, torch.Tensor)
+        torch.testing.assert_close(
+            observation, torch.tensor([2.0, 0.25, 1.5, 1.0, 5.5])
+        )
+
+        action_result = env.step(torch.tensor(0))
+        self.assertIsInstance(action_result.observation, torch.Tensor)
+        torch.testing.assert_close(
+            action_result.observation, torch.tensor([1.0, -0.5, 0.5, 0.0, 6.0])
+        )
+
+    def test_tuple_action_spaces_remain_unsupported(self) -> None:
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "The Gym space 'Tuple' is not yet supported in Pearl.",
+        ):
+            GymEnvironment(TupleActionEnv())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Add support for Gym/Gymnasium `Tuple` observation spaces in `GymEnvironment`
- Flatten tuple observations from `reset()` and `step()` into 1-D tensors
- Convert tuple observation spaces into flattened `BoxSpace` bounds
- Keep `Tuple` action spaces unsupported

This addresses the Tuple observation-space case from #54, including environments such as `Blackjack-v1`.

Test Plan:
- `python -m unittest test.unit.test_gym_environment`
- `python -m unittest test.unit.test_flatten_dict_observations`
- `python -m unittest test.unit.test_tutorials.test_frozen_lake`