### PR TITLE
ci: scope workflow token to read-only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,9 @@
 name: Workflow for CI and Codecov Action
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to the CI workflow.

The workflow installs Python dependencies, generates documentation, uploads artifacts, runs tests, and uploads coverage to Codecov (using a separate token). None of these require write access to the repository via GITHUB_TOKEN. Restricting token scope follows least-privilege guidance for GitHub Actions.